### PR TITLE
 Various Changes

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -17,6 +17,8 @@ Config.QualityDegrade = {min = 8, max = 12}
 Config.GrowthIncrease = {min = 10, max = 20}
 Config.MaxPlantCount = 40 -- maximum plants play can have at any one time
 Config.UseFarmingZones = true -- true = use farmzones / false = no farmzones
+Config.UseSeedBasedZones = true -- true = use seed based farmzones / false = no seed based specific farmzones
+Config.NotificationSound = true -- when UseSeedBasedZones is enabled, play notification sound when the player is doing some actions
 Config.CollectWaterTime = 30000 -- time set to collect water
 Config.CollectPooTime = 30000 -- time set to collect fertilizer
 
@@ -145,6 +147,7 @@ Config.FarmZone = {
             vector2(-349.36514282227, 941.19653320313)
         },
         name = "farmzone1",
+        blipname = 'farmzone1 Farm Zone',
         minZ = 115.78807830811,
         maxZ = 122.06151580811,
         showblip = true,


### PR DESCRIPTION
- Add seed based zones feature to limit the type of seeds a player can plant on a farm zone

    Example:

        Config.FarmZone = {
            [1] = {
                zones = { -- corn
                    vector2(1186.67, 397.82),
                    vector2(1169.27, 411.02),
                    vector2(1152.04, 392.62),
                    vector2(1165.41, 379.7)
                },
                name = "corn",
                blipname = 'Corn Farm Zone',
                minZ = 90.89,
                maxZ = 120.06151580811,
                showblip = true,
                blipcoords = vector3(1171.58, 397.46, 91.73)
            },
        }

    Will only allow players to plant corn seeds on the area.

- Add seed based map blip name, so instead of showing a generic 'Farming Zone' it will display 'Corn Farm Zone'
- Add/change notification text and sound when the player is doing some actions
- Some logic optimisations
- etc