### PR TITLE
Various Changes

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -152,7 +152,7 @@ AddEventHandler('rsg-farmer:server:destroyPlant', function(plantId)
             table.remove(Config.FarmPlants, k)
         end
     end
-    TriggerClientEvent('rsg-farmer:client:removePlantObject', src, plantId)
+    TriggerClientEvent('rsg-farmer:client:removePlantObject', -1, plantId)
     TriggerEvent('rsg-farmer:server:PlantRemoved', plantId)
     TriggerEvent('rsg-farmer:server:updatePlants')
     TriggerClientEvent('RSGCore:Notify', src, 'you distroyed the plant', 'success')
@@ -210,7 +210,7 @@ AddEventHandler('rsg-farmer:server:harvestPlant', function(plantId)
         else
             print("something went wrong!")
         end
-        TriggerClientEvent('rsg-farmer:client:removePlantObject', src, plantId)
+        TriggerClientEvent('rsg-farmer:client:removePlantObject', -1, plantId)
         TriggerEvent('rsg-farmer:server:PlantRemoved', plantId)
         TriggerEvent('rsg-farmer:server:updatePlants')
     end


### PR DESCRIPTION
- Fix plant objects not getting removed when a Player doing harvest/destroy, other players can still see it even though the Player already seen it removed
- Remove plant objects when doing 'ensure' to make sure the plant objects don't get respawned over and over again after every 'ensure'
- Add back 'PlayerJob' definition after doing 'ensure' to make sure the job get read properly, eliminating the needs to set the job manually after 'ensure'
- etc